### PR TITLE
Spruce up the list of possible runes for 'random secret' generation.

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -91,7 +91,7 @@ func Itob(integer int) []byte {
 	return byteArr
 }
 
-// generate a random secret of given length
+// RandomSecret generates a random secret of given length from all possible printable ASCII characters.
 func RandomSecret(length int) string {
 	// secretRunes is all runes which may be used in a valid RandomSecret.
 	secretRunes := []rune{}
@@ -108,4 +108,9 @@ func RandomSecret(length int) string {
 	}
 
 	return string(bytes)
+}
+
+// UrlSafeRandomSecret generates a RandomSecret and returns it with url-safe encoding.
+func UrlSafeRandomSecret(l int) string {
+	return url.QueryEscape(RandomSecret(l))
 }

--- a/utils.go
+++ b/utils.go
@@ -30,7 +30,7 @@ var (
 )
 
 /*
-Returns the provisioning URI for the OTP; works for either TOTP or HOTP.
+BuildUri returns the provisioning URI for the OTP; works for either TOTP or HOTP.
 This can then be encoded in a QR Code and used to provision the Google Authenticator app.
 For module-internal use.
 See also:
@@ -76,12 +76,12 @@ func BuildUri(otpType, secret, accountName, issuerName, algorithm string, initia
 	return fmt.Sprintf("otpauth://%s/%s?%s", otpType, label, strings.Join(urlParams, "&"))
 }
 
-// get current timestamp
+// currentTimestamp returns the current timestamp.
 func currentTimestamp() int {
 	return int(time.Now().Unix())
 }
 
-// integer to byte array
+// Itob converts an integer to byte array
 func Itob(integer int) []byte {
 	byteArr := make([]byte, 8)
 	for i := 7; i >= 0; i-- {

--- a/utils.go
+++ b/utils.go
@@ -13,6 +13,22 @@ const (
 	OtpTypeHotp = "hotp"
 )
 
+var (
+	// slices of possible runes for secret creation.
+	digitRunes   = []rune("0123456789")
+	lCaseRunes   = []rune("abcdefghijklmnopqrstuvwxyz")
+	uCaseRunes   = []rune("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	specialRunes = []rune("~=+%^*/()[]{}/!@#$?|")
+
+	// A collection of all runes which may be used in creating a new secret.
+	allRunes = [][]rune{
+		digitRunes,
+		lCaseRunes,
+		uCaseRunes,
+		specialRunes,
+	}
+)
+
 /*
 Returns the provisioning URI for the OTP; works for either TOTP or HOTP.
 This can then be encoded in a QR Code and used to provision the Google Authenticator app.
@@ -77,13 +93,18 @@ func Itob(integer int) []byte {
 
 // generate a random secret of given length
 func RandomSecret(length int) string {
+	// secretRunes is all runes which may be used in a valid RandomSecret.
+	secretRunes := []rune{}
+	for _, r := range allRunes {
+		secretRunes = append(secretRunes, r...)
+	}
+
 	rand.Seed(time.Now().UnixNano())
-	letterRunes := []rune("ABCDEFGHIJKLMNOPQRSTUVWXYZ234567")
 
 	bytes := make([]rune, length)
 
 	for i := range bytes {
-		bytes[i] = letterRunes[rand.Intn(len(letterRunes))]
+		bytes[i] = secretRunes[rand.Intn(len(secretRunes))]
 	}
 
 	return string(bytes)

--- a/utils.go
+++ b/utils.go
@@ -1,6 +1,7 @@
 package gotp
 
 import (
+	"encoding/base32"
 	"fmt"
 	"math/rand"
 	"net/url"
@@ -107,7 +108,7 @@ func RandomSecret(length int) string {
 		bytes[i] = secretRunes[rand.Intn(len(secretRunes))]
 	}
 
-	return string(bytes)
+	return base32.StdEncoding.EncodeToString(bytes)
 }
 
 // UrlSafeRandomSecret generates a RandomSecret and returns it with url-safe encoding.


### PR DESCRIPTION
Permit upper/lower case alpha characters.
Permit numbers.
Permit the printable ascii speical characters.