### PR TITLE
Add utils - TOPT.AtTime, IsSecretValid, and int64 of timestamps

### DIFF
--- a/hotp.go
+++ b/hotp.go
@@ -17,7 +17,7 @@ func NewDefaultHOTP(secret string) *HOTP {
 
 // Generates the OTP for the given count.
 func (h *HOTP) At(count int) string {
-	return h.generateOTP(count)
+	return h.generateOTP(int64(count))
 }
 
 /*

--- a/otp.go
+++ b/otp.go
@@ -39,7 +39,7 @@ func NewOTP(secret string, digits int, hasher *Hasher) OTP {
 params
     input: the HMAC counter value to use as the OTP input. Usually either the counter, or the computed integer based on the Unix timestamp
 */
-func (o *OTP) generateOTP(input int) string {
+func (o *OTP) generateOTP(input int64) string {
 	if input < 0 {
 		panic("input must be positive integer")
 	}

--- a/totp.go
+++ b/totp.go
@@ -5,10 +5,10 @@ import "time"
 // time-based OTP counters.
 type TOTP struct {
 	OTP
-	interval int64
+	interval int
 }
 
-func NewTOTP(secret string, digits int, interval int64, hasher *Hasher) *TOTP {
+func NewTOTP(secret string, digits, interval int, hasher *Hasher) *TOTP {
 	otp := NewOTP(secret, digits, hasher)
 	return &TOTP{OTP: otp, interval: interval}
 }
@@ -80,5 +80,5 @@ func (t *TOTP) ProvisioningUri(accountName, issuerName string) string {
 }
 
 func (t *TOTP) timecode(timestamp int64) int64 {
-	return int64(timestamp / t.interval)
+	return timestamp / int64(t.interval)
 }

--- a/totp.go
+++ b/totp.go
@@ -22,6 +22,10 @@ func (t *TOTP) At(timestamp int64) string {
 	return t.generateOTP(t.timecode(timestamp))
 }
 
+func (t *TOTP) AtTime(timestamp time.Time) string {
+	return t.At(timestamp.Unix())
+}
+
 // Generate the current time OTP
 func (t *TOTP) Now() string {
 	return t.At(currentTimestamp())

--- a/totp.go
+++ b/totp.go
@@ -5,10 +5,10 @@ import "time"
 // time-based OTP counters.
 type TOTP struct {
 	OTP
-	interval int
+	interval int64
 }
 
-func NewTOTP(secret string, digits, interval int, hasher *Hasher) *TOTP {
+func NewTOTP(secret string, digits int, interval int64, hasher *Hasher) *TOTP {
 	otp := NewOTP(secret, digits, hasher)
 	return &TOTP{OTP: otp, interval: interval}
 }
@@ -18,7 +18,7 @@ func NewDefaultTOTP(secret string) *TOTP {
 }
 
 // Generate time OTP of given timestamp
-func (t *TOTP) At(timestamp int) string {
+func (t *TOTP) At(timestamp int64) string {
 	return t.generateOTP(t.timecode(timestamp))
 }
 
@@ -32,7 +32,7 @@ func (t *TOTP) NowWithExpiration() (string, int64) {
 	interval64 := int64(t.interval)
 	timeCodeInt64 := time.Now().Unix() / interval64
 	expirationTime := (timeCodeInt64 + 1) * interval64
-	return t.generateOTP(int(timeCodeInt64)), expirationTime
+	return t.generateOTP(timeCodeInt64), expirationTime
 }
 
 /*
@@ -42,8 +42,12 @@ params:
     otp:         the OTP to check against
     timestamp:   time to check OTP at
 */
-func (t *TOTP) Verify(otp string, timestamp int) bool {
+func (t *TOTP) Verify(otp string, timestamp int64) bool {
 	return otp == t.At(timestamp)
+}
+
+func (t *TOTP) VerifyTime(otp string, timestamp time.Time) bool {
+	return t.Verify(otp, timestamp.Unix())
 }
 
 /*
@@ -71,6 +75,6 @@ func (t *TOTP) ProvisioningUri(accountName, issuerName string) string {
 		t.interval)
 }
 
-func (t *TOTP) timecode(timestamp int) int {
-	return int(timestamp / t.interval)
+func (t *TOTP) timecode(timestamp int64) int64 {
+	return int64(timestamp / t.interval)
 }

--- a/totp_test.go
+++ b/totp_test.go
@@ -18,7 +18,7 @@ func TestTOTP_NowWithExpiration(t *testing.T) {
 	if otp != totp.Now() {
 		t.Error("TOTP generate otp error!")
 	}
-	if totp.At(cts+30) != totp.At(int(exp)) {
+	if totp.At(cts+30) != totp.At(exp) {
 		t.Error("TOTP expiration otp error!")
 	}
 }

--- a/totp_test.go
+++ b/totp_test.go
@@ -2,6 +2,7 @@ package gotp
 
 import (
 	"testing"
+	"time"
 )
 
 var totp = NewDefaultTOTP("4S62BZNFXXSZLCRO")
@@ -9,6 +10,12 @@ var totp = NewDefaultTOTP("4S62BZNFXXSZLCRO")
 func TestTOTP_At(t *testing.T) {
 	if totp.Now() != totp.At(currentTimestamp()) {
 		t.Error("TOTP generate otp error!")
+	}
+}
+
+func TestTOTP_AtTime(t *testing.T) {
+	if totp.Now() != totp.AtTime(time.Now()) {
+		t.Error("TOTP at time generate otp error!")
 	}
 }
 

--- a/utils.go
+++ b/utils.go
@@ -33,7 +33,7 @@ params:
 
 returns: provisioning uri
 */
-func BuildUri(otpType, secret, accountName, issuerName, algorithm string, initialCount, digits int, period int64) string {
+func BuildUri(otpType, secret, accountName, issuerName, algorithm string, initialCount, digits int, period int) string {
 	q := url.Values{}
 
 	if otpType != OtpTypeHotp && otpType != OtpTypeTotp {

--- a/utils.go
+++ b/utils.go
@@ -95,3 +95,13 @@ func RandomSecret(length int) string {
 	result = encoder.EncodeToString(secret)
 	return result
 }
+
+// A non-panic way of seeing weather or not a given secret is valid
+func IsSecretValid(secret string) bool {
+	missingPadding := len(secret) % 8
+	if missingPadding != 0 {
+		secret = secret + strings.Repeat("=", 8-missingPadding)
+	}
+	_, err := base32.StdEncoding.DecodeString(secret)
+	return err == nil
+}

--- a/utils.go
+++ b/utils.go
@@ -33,7 +33,7 @@ params:
 
 returns: provisioning uri
 */
-func BuildUri(otpType, secret, accountName, issuerName, algorithm string, initialCount, digits, period int) string {
+func BuildUri(otpType, secret, accountName, issuerName, algorithm string, initialCount, digits int, period int64) string {
 	q := url.Values{}
 
 	if otpType != OtpTypeHotp && otpType != OtpTypeTotp {
@@ -67,12 +67,12 @@ func BuildUri(otpType, secret, accountName, issuerName, algorithm string, initia
 }
 
 // get current timestamp
-func currentTimestamp() int {
-	return int(time.Now().Unix())
+func currentTimestamp() int64 {
+	return time.Now().Unix()
 }
 
 // integer to byte array
-func Itob(integer int) []byte {
+func Itob(integer int64) []byte {
 	byteArr := make([]byte, 8)
 	for i := 7; i >= 0; i-- {
 		byteArr[i] = byte(integer & 0xff)

--- a/utils_test.go
+++ b/utils_test.go
@@ -36,7 +36,7 @@ func TestBuildUri(t *testing.T) {
 }
 
 func TestITob(t *testing.T) {
-	i := 1524486261
+	var i int64 = 1524486261
 	expect := []byte{0, 0, 0, 0, 90, 221, 208, 117}
 
 	if string(expect) != string(Itob(i)) {

--- a/utils_test.go
+++ b/utils_test.go
@@ -50,3 +50,14 @@ func TestRandomSecret(t *testing.T) {
 		t.Error("RandomSecret error")
 	}
 }
+
+func TestIsSecretValid(t *testing.T) {
+	valid := RandomSecret(64)
+	if !IsSecretValid(valid) {
+		t.Error("IsSecretValid error - RandomSecret(64) is not valid")
+	}
+	invalid := "asdsada"
+	if IsSecretValid(invalid) {
+		t.Error("IsSecretValid error - Bad secret is valid")
+	}
+}


### PR DESCRIPTION
Hello! This is a small PR that resolves issue #6, #10 and #18. I think this would be considered a breaking change, since I changed the types from int to int64 to all timestamps & intervals. I didn't change it to digits, because I don't see how that is related to timestamps & so it shouldn't really matter. 

For IsSecretValid(), I just copied an already existing method of OTP.byteSecret, but instead of panic on an error, I just return false. 

I don't have a lot of experience with test making, so I just used the other tests as an example for the tests. Please, feel free to edit this if there is something not up to standard!